### PR TITLE
fix domain size

### DIFF
--- a/plonk/src/nightfall/circuit/plonk_partial_verifier/mod.rs
+++ b/plonk/src/nightfall/circuit/plonk_partial_verifier/mod.rs
@@ -36,6 +36,10 @@ pub use poly::*;
 pub use proof_to_var::*;
 pub use structs::*;
 
+// We assume TRANSFER_DOMAIN_SIZE is always at most DEPOSIT_DOMAIN_SIZE.
+pub(crate) const TRANSFER_DOMAIN_SIZE: usize = 1 << 15;
+pub(crate) const DEPOSIT_DOMAIN_SIZE: usize = 1 << 18;
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Represent variable of a Plonk verifying key.
 pub struct VerifyingKeyVar<PCS: PolynomialCommitmentScheme> {
@@ -399,7 +403,7 @@ mod test {
 
             let pi_var = circuit.create_variable(pi)?;
 
-            let scalars = compute_scalars_for_native_field::<P::ScalarField>(
+            let scalars = compute_scalars_for_native_field::<P::ScalarField, false>(
                 &mut circuit,
                 pi_var,
                 &challenges_var,
@@ -473,14 +477,14 @@ mod test {
         };
 
         let vk_k = vec![circuit.zero(); 6];
-        let scalars = compute_scalars_for_native_field::<Fr254>(
+        let scalars = compute_scalars_for_native_field::<Fr254, true>(
             &mut circuit,
             0,
             &challenges_var,
             &proof_evals,
             Some(lookup_evals),
             &vk_k,
-            1 << 15,
+            TRANSFER_DOMAIN_SIZE,
         )
         .unwrap();
 

--- a/plonk/src/recursion/circuits/fft_arithmetic.rs
+++ b/plonk/src/recursion/circuits/fft_arithmetic.rs
@@ -64,7 +64,7 @@ impl PCSInfoCircuit {
 }
 
 /// This function takes as input an FFT proof and verifies its transcript and produces the scalars that should be used to calculate its final commitment.
-pub fn partial_verify_fft_plonk(
+pub fn partial_verify_fft_plonk<const IS_BASE: bool>(
     output: &RecursiveOutput<Kzg, FFTPlonk<Kzg>, RescueTranscript<Fr254>>,
     vk: &VerifyingKey<Kzg>,
     circuit: &mut PlonkCircuit<Fr254>,
@@ -95,7 +95,7 @@ pub fn partial_verify_fft_plonk(
         vk.k.iter()
             .map(|k| circuit.create_variable(*k))
             .collect::<Result<Vec<Variable>, CircuitError>>()?;
-    let scalars = compute_scalars_for_native_field(
+    let scalars = compute_scalars_for_native_field::<Fr254, IS_BASE>(
         circuit,
         pi_hash,
         &challenges,
@@ -124,7 +124,7 @@ pub fn calculate_recursion_scalars(
     // First prepare the pcs_infos for each proof
     let pcs_infos = outputs
         .iter()
-        .map(|output| partial_verify_fft_plonk(output, vk, circuit))
+        .map(|output| partial_verify_fft_plonk::<false>(output, vk, circuit))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Now we transform the 'old_accs' into the relevant circuit variables
@@ -218,7 +218,7 @@ pub fn calculate_recursion_scalars_base(
     let pcs_infos = outputs
         .iter()
         .zip(vks.iter())
-        .map(|(output, vk)| partial_verify_fft_plonk(output, vk, circuit))
+        .map(|(output, vk)| partial_verify_fft_plonk::<true>(output, vk, circuit))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Now we transform the 'old_accs' into the relevant circuit variables
@@ -416,7 +416,8 @@ mod tests {
             )?;
 
             let mut verifier_circuit = PlonkCircuit::<Fr254>::new_ultra_plonk(8);
-            let pcs_info_circuit = partial_verify_fft_plonk(&output, &vk, &mut verifier_circuit)?;
+            let pcs_info_circuit =
+                partial_verify_fft_plonk::<false>(&output, &vk, &mut verifier_circuit)?;
 
             let fft_verifier = FFTVerifier::<Kzg>::new(vk.domain_size)?;
 


### PR DESCRIPTION
Fixes the variable `domain_size` problem we were having by constraining `domain_size` in the appropriate circuit to be either `2^15` or `2^18`. (These are the domain sizes for the transfer/withdraw and deposit circuits respectively.) Note that this is only a problem in the base BN254 circuits (the next BN254 layer after the client circuits). In all other layers we consider this `domain_size` as a constant.