### PR TITLE
Livesey/fix public inputs

### DIFF
--- a/plonk/src/recursion/merge_functions.rs
+++ b/plonk/src/recursion/merge_functions.rs
@@ -1684,9 +1684,6 @@ fn convert_to_hash_form(
     let low_var = circuit.create_variable(low_elem)?;
     let high_var = circuit.create_variable(high_elem)?;
 
-    circuit.enforce_in_range(low_var, 8 * 31)?;
-    circuit.enforce_in_range(high_var, 6)?;
-
     circuit.lc_gate(
         &[low_var, high_var, circuit.zero(), circuit.zero(), var],
         &[Fr254::one(), coeff, Fr254::zero(), Fr254::zero()],
@@ -1713,9 +1710,6 @@ fn convert_to_hash_form_fq254(
 
     let low_var = circuit.create_variable(low_elem)?;
     let high_var = circuit.create_variable(high_elem)?;
-
-    circuit.enforce_in_range(low_var, 8 * 31)?;
-    circuit.enforce_in_range(high_var, 6)?;
 
     circuit.lc_gate(
         &[low_var, high_var, circuit.zero(), circuit.zero(), var],

--- a/relation/src/gadgets/emulated.rs
+++ b/relation/src/gadgets/emulated.rs
@@ -291,12 +291,10 @@ impl<F: PrimeField> PlonkCircuit<F> {
                 let lower_val = val.clone() % (BigUint::from(2u32).pow(power));
                 let lower_var = self.create_variable(F::from(lower_val))?;
                 emu_var_vec.push(lower_var);
-                self.enforce_in_range(lower_var, power as usize)?;
                 coeff_vec.push(coeff);
 
                 let carry_val = val / (BigUint::from(2u32).pow(power));
                 carry_var = self.create_variable(F::from(carry_val))?;
-                self.enforce_in_range(carry_var, E::B - power as usize)?;
 
                 // `lower_var` and `carry_var` must decompose the `Variable` that straddles two `field_limb_vars`.
                 self.lin_comb_gate(


### PR DESCRIPTION
This PR does a couple of things. Firstly, I've removed the `enforce_in_range` checks in the `convert_to_hash` and `convert_for_transcript` functions. The reason is that the outputs of these functions are always immediately hashed and then pushed to a transcript. If a malicious prover tries to `convert_to_hash` or `convert_for_transcript` in a dishonest way, the resulting proof will fail (due to an incorrect input to the transcript) with all but negligible probability.

Secondly I've introduced the `bn254_acc_vars` and `pi_hash_vars` `Variable`s. Previously each of these were two sets of `Variable`s, one of which was made public, the other of which was used in the proof. Now each of them is just one set of `Variable`s that are then made public after being used in the proof. That way, the public `Variable`s are "tied" to the proof and not just completely independent.

Please ask me if anything is unclear.