### PR TITLE
fix: constrain pi_hash to be equal to the instance used in `reconstruct_mle_challenges`

### DIFF
--- a/plonk/src/recursion/circuits/mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/mle_arithmetic.rs
@@ -925,6 +925,9 @@ mod tests {
             let mle_proof_challenges = outputs
                 .iter()
                 .map(|output| {
+                    let pi_hash = challenges_circuit
+                        .create_emulated_variable(output.pi_hash)
+                        .unwrap();
                     let (stuff, _) = reconstruct_mle_challenges::<
                         _,
                         _,
@@ -932,7 +935,9 @@ mod tests {
                         _,
                         RescueTranscript<Fr254>,
                         RescueTranscriptVar<Fr254>,
-                    >(output, &vk_var, &mut challenges_circuit)
+                    >(
+                        output, &vk_var, &mut challenges_circuit, &pi_hash
+                    )
                     .unwrap();
                     stuff
                 })

--- a/plonk/src/recursion/merge_functions.rs
+++ b/plonk/src/recursion/merge_functions.rs
@@ -1259,6 +1259,7 @@ pub fn prove_grumpkin_accumulation<const IS_BASE: bool>(
                         fr_to_fq::<Fr254, SWGrumpkin>(&output.pi_hash)
                     );
                 }
+                let pi_hash_emul: EmulatedVariable<Fq254> = circuit.to_emulated_variable(pi_hash)?;
 
                 let next_grumpkin_challenges = reconstruct_mle_challenges::<
                     _,
@@ -1267,7 +1268,7 @@ pub fn prove_grumpkin_accumulation<const IS_BASE: bool>(
                     _,
                     RescueTranscript<Fr254>,
                     RescueTranscriptVar<Fr254>,
-                >(output, &vk_var, circuit)?;
+                >(output, &vk_var, circuit, &pi_hash_emul)?;
                 Ok(next_grumpkin_challenges)
             },
         )


### PR DESCRIPTION
Fixes #80 