### PR TITLE
make mle vks constant

### DIFF
--- a/plonk/src/nightfall/mle/mle_structs.rs
+++ b/plonk/src/nightfall/mle/mle_structs.rs
@@ -368,7 +368,6 @@ impl<F: PrimeField> MLEChallenges<F> {
     pub fn new<PCS, P, T>(
         proof: &MLEProof<PCS>,
         public_input: &[F],
-        vk: &MLEVerifyingKey<PCS>,
         transcript: &mut T,
     ) -> Result<Self, PlonkError>
     where
@@ -378,9 +377,7 @@ impl<F: PrimeField> MLEChallenges<F> {
         PCS: PolynomialCommitmentScheme<Commitment = Affine<P>, Evaluation = P::ScalarField>,
         T: Transcript,
     {
-        // Append Vk and public input to transcript.
-        transcript.append_visitor(vk)?;
-
+        // Append public input to transcript.
         for pi in public_input.iter() {
             transcript.push_message(b"public input", pi)?;
         }
@@ -419,7 +416,6 @@ impl<F: PrimeField> MLEChallenges<F> {
     pub fn new_recursion<PCS, P, T>(
         proof: &SAMLEProof<PCS>,
         public_input: &[F],
-        vk: &MLEVerifyingKey<PCS>,
         transcript: &mut T,
     ) -> Result<Self, PlonkError>
     where
@@ -434,9 +430,7 @@ impl<F: PrimeField> MLEChallenges<F> {
         >,
         T: Transcript,
     {
-        // Append Vk and public input to transcript.
-        transcript.append_visitor(vk)?;
-
+        // Append public input to transcript.
         transcript.push_message(b"public input", &public_input[0])?;
 
         // We know that the commitments we are using will always be points on an SW curve.

--- a/plonk/src/nightfall/mle/snark.rs
+++ b/plonk/src/nightfall/mle/snark.rs
@@ -209,9 +209,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
     {
         let mut transcript = T::new_transcript(b"mle_plonk");
 
-        // Append Vk and public input to transcript.
-        transcript.append_visitor(&pk.verifying_key)?;
-
+        // Append public input to transcript.
         for public_input in circuit.public_input()? {
             transcript.push_message(b"public input", &public_input)?;
         }
@@ -575,9 +573,6 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
 
         let mut transcript = T::new_transcript(b"mle_plonk");
 
-        // Append Vk to the transcript.
-        transcript.append_visitor(&pk.verifying_key)?;
-
         // Compute the wire polynomials.
         let wire_polys = circuit.compute_wire_mles()?;
 
@@ -848,7 +843,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         let pi_poly = DenseMultilinearExtension::from_evaluations_vec(num_vars, pi_evals);
 
         let challenges =
-            MLEChallenges::<P::ScalarField>::new(proof, public_input, vk, &mut transcript)?;
+            MLEChallenges::<P::ScalarField>::new(proof, public_input, &mut transcript)?;
 
         let gkr_deferred_check = batch_verify_gkr::<P, _>(&proof.gkr_proof, &mut transcript)?;
 
@@ -1062,7 +1057,6 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         let challenges = MLEChallenges::<P::ScalarField>::new_recursion(
             proof,
             &[public_input],
-            vk,
             &mut transcript,
         )?;
 

--- a/plonk/src/recursion/circuits/challenges.rs
+++ b/plonk/src/recursion/circuits/challenges.rs
@@ -16,7 +16,7 @@ use crate::{
     errors::PlonkError,
     nightfall::{
         circuit::{
-            plonk_partial_verifier::{MLEChallengesVar, MLEVerifyingKeyVar, SAMLEProofVar},
+            plonk_partial_verifier::{MLEChallengesVar, SAMLEProofVar},
             subroutine_verifiers::sumcheck::SumCheckGadget,
         },
         mle::mle_structs::{MLEChallenges, SAMLEProof},
@@ -125,7 +125,6 @@ impl<F: PrimeField> MLEProofChallenges<F> {
 /// It is assumed that this circuit is defined over the same field that commitments are. By returning the challenges we mean that it sets the associate variables to be public.
 pub fn reconstruct_mle_challenges<P, F, PCS, Scheme, T, C>(
     output: &RecursiveOutput<PCS, Scheme, T>,
-    vk: &MLEVerifyingKeyVar<PCS>,
     circuit: &mut PlonkCircuit<F>,
     pi_hash: &EmulatedVariable<P::ScalarField>,
 ) -> Result<(MLEProofChallenges<P::ScalarField>, C), CircuitError>
@@ -150,7 +149,7 @@ where
 
     // Now we begin by recovering the circuit version of the MLEChallenges struct.
     let mle_challenges =
-        MLEChallengesVar::compute_challenges(circuit, vk, pi_hash, &proof_var, &mut transcript)?;
+        MLEChallengesVar::compute_challenges(circuit, pi_hash, &proof_var, &mut transcript)?;
 
     let mle_challenges_field = mle_challenges.to_field(circuit)?;
     // Next we need to know the number of variables the polynomials used in the proof had, this is the same as `proof_var.opening_point_var.len()`.

--- a/plonk/src/recursion/circuits/emulated_mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/emulated_mle_arithmetic.rs
@@ -10,11 +10,11 @@ use crate::{
         circuit::{
             plonk_partial_verifier::{
                 emulated_eq_x_r_eval_circuit, EmulatedMLEChallenges, MLELookupEvaluationsVar,
-                MLEProofEvaluationsVar, MLEVerifyingKeyVar, SAMLEProofVar,
+                MLEProofEvaluationsVar, SAMLEProofVar,
             },
             subroutine_verifiers::{structs::EmulatedSumCheckProofVar, sumcheck::SumCheckGadget},
         },
-        mle::mle_structs::{GateInfo, MLEVerifyingKey},
+        mle::mle_structs::GateInfo,
     },
     recursion::merge_functions::GrumpkinOutput,
     transcript::{rescue::RescueTranscriptVar, CircuitTranscript},
@@ -427,10 +427,9 @@ type MLEScalarsAndAccEval = (Vec<EmulatedVariable<Fq254>>, EmulatedVariable<Fq25
 pub fn emulated_combine_mle_proof_scalars(
     outputs: &[GrumpkinOutput],
     acc_info: &SplitAccumulationInfo,
-    vk: &MLEVerifyingKey<Zmorph>,
+    gate_info: &GateInfo<Fq254>,
     circuit: &mut PlonkCircuit<Fr254>,
 ) -> Result<MLEScalarsAndAccEval, CircuitError> {
-    let vk_var = MLEVerifyingKeyVar::<Zmorph>::new(circuit, vk)?;
     let mut scalar_list = Vec::new();
     let mut evals = Vec::new();
     let mut points = Vec::new();
@@ -442,7 +441,6 @@ pub fn emulated_combine_mle_proof_scalars(
         let mut transcript_var = RescueTranscriptVar::<Fr254>::new_transcript(circuit);
         let challenges = EmulatedMLEChallenges::<Fq254>::compute_challenges_vars(
             circuit,
-            &vk_var,
             &pi,
             &proof_var,
             &mut transcript_var,
@@ -466,7 +464,7 @@ pub fn emulated_combine_mle_proof_scalars(
             &challenges,
             &pi_eval,
             &mut transcript_var,
-            &vk.gate_info,
+            gate_info,
         )?;
 
         scalar_list.push(scalars);
@@ -658,7 +656,7 @@ mod tests {
             let (combined_scalars, combined_eval) = emulated_combine_mle_proof_scalars(
                 &outputs,
                 &split_acc_info,
-                &vk,
+                &vk.gate_info,
                 &mut verifier_circuit,
             )?;
 

--- a/plonk/src/recursion/circuits/mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/mle_arithmetic.rs
@@ -675,10 +675,7 @@ mod tests {
         errors::PlonkError,
         nightfall::{
             accumulation::accumulation_structs::PCSWitness,
-            circuit::{
-                plonk_partial_verifier::MLEVerifyingKeyVar,
-                subroutine_verifiers::gkr::tests::extract_gkr_challenges,
-            },
+            circuit::subroutine_verifiers::gkr::tests::extract_gkr_challenges,
             mle::{
                 mle_structs::MLEChallenges, snark::tests::gen_circuit_for_test,
                 zeromorph::Zeromorph, MLEPlonk,
@@ -750,7 +747,6 @@ mod tests {
             let mle_challenges = MLEChallenges::<P::ScalarField>::new_recursion(
                 &proof.proof,
                 &[public_input[0]],
-                &_vk1,
                 &mut transcript,
             )
             .unwrap();
@@ -921,24 +917,22 @@ mod tests {
             )?;
 
             let mut challenges_circuit = PlonkCircuit::<Fr254>::new_ultra_plonk(8);
-            let vk_var = MLEVerifyingKeyVar::new(&mut challenges_circuit, &vk)?;
             let mle_proof_challenges = outputs
                 .iter()
                 .map(|output| {
                     let pi_hash = challenges_circuit
                         .create_emulated_variable(output.pi_hash)
                         .unwrap();
-                    let (stuff, _) = reconstruct_mle_challenges::<
-                        _,
-                        _,
-                        _,
-                        _,
-                        RescueTranscript<Fr254>,
-                        RescueTranscriptVar<Fr254>,
-                    >(
-                        output, &vk_var, &mut challenges_circuit, &pi_hash
-                    )
-                    .unwrap();
+                    let (stuff, _) =
+                        reconstruct_mle_challenges::<
+                            _,
+                            _,
+                            _,
+                            _,
+                            RescueTranscript<Fr254>,
+                            RescueTranscriptVar<Fr254>,
+                        >(output, &mut challenges_circuit, &pi_hash)
+                        .unwrap();
                     stuff
                 })
                 .collect::<Vec<MLEProofChallenges<Fq254>>>();

--- a/plonk/src/recursion/merge_functions.rs
+++ b/plonk/src/recursion/merge_functions.rs
@@ -1253,9 +1253,6 @@ pub fn prove_grumpkin_accumulation<const IS_BASE: bool>(
         .collect::<Result<Vec<Vec<Variable>>, CircuitError>>()?
     };
 
-    // Make a vk variable
-    let vk_var = MLEVerifyingKeyVar::new(circuit, &pk_grumpkin.verifying_key)?;
-
     // Now we make variables for the specific pi as we will have to use these in the following for loop and later on.
     let impl_specific_pi = grumpkin_info
         .specific_pi
@@ -1487,7 +1484,7 @@ pub fn prove_grumpkin_accumulation<const IS_BASE: bool>(
                     _,
                     RescueTranscript<Fr254>,
                     RescueTranscriptVar<Fr254>,
-                >(output, &vk_var, circuit, &pi_hash_emul)?;
+                >(output, circuit, &pi_hash_emul)?;
                 Ok(next_grumpkin_challenges)
             },
         )
@@ -1651,7 +1648,7 @@ pub fn decider_circuit(
     .collect::<Result<Vec<Vec<Variable>>, CircuitError>>()?;
 
     // Make a vk variable
-    let vk_var = MLEVerifyingKeyVar::new(circuit, &pk_grumpkin.verifying_key)?;
+    let vk_var = MLEVerifyingKeyVar::new_constant(circuit, &pk_grumpkin.verifying_key)?;
 
     // Now we make variables for the specific pi as we will have to use these in the following for loop and later on.
     let impl_specific_pi = grumpkin_info
@@ -1854,7 +1851,7 @@ pub fn decider_circuit(
     let (msm_scalars, acc_eval) = emulated_combine_mle_proof_scalars(
         &grumpkin_info.grumpkin_outputs,
         &split_acc_info,
-        &pk_grumpkin.verifying_key,
+        &pk_grumpkin.verifying_key.gate_info,
         circuit,
     )?;
 


### PR DESCRIPTION
Closes #81. The only remaining task was to deal with the `MLEVerifyingKeyVar`. This was much simpler than the `FFTPlonk` case as the `MLEVerifiyingKey`s are fixed across a layer.

In the `merge_grumpkin_circuit` I decided to remove the `MLEVerifyingKeyVar` entirely. Its only purpose was to be added to the transcript and this is really not necessary as it's fixed. The key is now not added to the transcript anywhere.

In the `decider_circuit` I constrained the `MLEVerifiyingKey` to be constant. I could have encoded it as selectors but the points are combined with some genuine variables, so it seemed easier to just make it constant.

This passes both Julian's recursive unit test and a test on the server.