### PR TITLE
Improve Code Quality for Sumcheck Protocol by Adding Sanity Checks and Handling Edge Cases

### DIFF
--- a/plonk/src/nightfall/accumulation/circuit/split_gadgets.rs
+++ b/plonk/src/nightfall/accumulation/circuit/split_gadgets.rs
@@ -316,8 +316,11 @@ where
         proof: &MVSplitProofVar<E::BaseField>,
     ) -> Result<(), CircuitError> {
         let l = old_instances.len().next_power_of_two().ilog2() as usize;
-        let eval =
-            <Self as SumCheckGadget<E::BaseField>>::verify_sum_check_with_challenges(self, proof)?;
+        let d = old_instances[0].point.len();
+        let num_rounds = l + d;
+        let eval = <Self as SumCheckGadget<E::BaseField>>::verify_sum_check_with_challenges(
+            self, proof, num_rounds,
+        )?;
 
         let a1 = &proof.point_var[..l];
         let a2 = &proof.point_var[l..];

--- a/plonk/src/nightfall/circuit/subroutine_verifiers/gkr.rs
+++ b/plonk/src/nightfall/circuit/subroutine_verifiers/gkr.rs
@@ -151,7 +151,8 @@ impl<F: PrimeField + RescueParameter> GKRProofVar<F> {
             let calc_initial_eval = sumcheck_initial_evaluation(evals, &lambda_powers, r, circuit)?;
             circuit.enforce_equal(calc_initial_eval, proof.eval_var)?;
 
-            res = circuit.verify_sum_check_with_challenges(proof)?;
+            let num_rounds = sumcheck_challenges.len();
+            res = circuit.verify_sum_check_with_challenges(proof, num_rounds)?;
             r = *r_challenge;
             sc_eq_eval = eq_x_r_eval_circuit(circuit, sumcheck_challenges, &challenge_point)?;
             challenge_point = [sumcheck_challenges.as_slice(), &[r]].concat();

--- a/plonk/src/nightfall/circuit/subroutine_verifiers/sumcheck.rs
+++ b/plonk/src/nightfall/circuit/subroutine_verifiers/sumcheck.rs
@@ -378,6 +378,10 @@ where
     {
         let num_rounds = sum_check_proof_var.point_var.len();
         let mut eval_var = sum_check_proof_var.eval_var;
+
+        assert_eq!(num_rounds, sum_check_proof_var.oracles_var.len());
+        assert_eq!(num_rounds, sum_check_proof_var.r_0_evals_var.len());
+
         transcript.push_variable(&eval_var)?;
         for i in 0..num_rounds {
             transcript.push_variable(&sum_check_proof_var.r_0_evals_var[i])?;

--- a/plonk/src/nightfall/mle/subroutines/mod.rs
+++ b/plonk/src/nightfall/mle/subroutines/mod.rs
@@ -12,14 +12,14 @@ use crate::{
     transcript::{Transcript, TranscriptVisitor},
 };
 
+use self::sumcheck::SumCheck;
 use ark_ff::{Field, PrimeField};
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, MultilinearExtension, Polynomial};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
     cfg_into_iter, cfg_iter_mut, marker::PhantomData, string::ToString, vec, vec::Vec, One, Zero,
 };
-
-use self::sumcheck::SumCheck;
+use itertools::Itertools;
 
 use rayon::prelude::*;
 
@@ -522,7 +522,8 @@ where
 
         transcript.push_message(b"eval", &proof.eval)?;
 
-        for (oracle, r_0_eval) in proof.oracles.iter().zip(proof.r_0_evals.iter()) {
+        assert_eq!(proof.oracles.len(), proof.point.len());
+        for (oracle, r_0_eval) in proof.oracles.iter().zip_eq(proof.r_0_evals.iter()) {
             let size = oracle.evaluations.len();
             // note that any affine transformation of the points does not change the result of the barycentric formula
             // however nonlinear transformations do change the result of the barycentric formula

--- a/plonk/src/recursion/circuits/mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/mle_arithmetic.rs
@@ -410,7 +410,9 @@ pub(crate) fn verify_mleplonk_scalar_arithmetic<F: PrimeField + RescueParameter>
     circuit.enforce_equal(initial_zerocheck_eval, proof.sumcheck_proof().eval_var)?;
 
     // Now we verify the arithmetic of the SumCheck proof.
-    let zerocheck_eval = circuit.verify_sum_check_with_challenges(proof.sumcheck_proof())?;
+    let num_rounds = gkr_sumcheck_challenges.len();
+    let zerocheck_eval =
+        circuit.verify_sum_check_with_challenges(proof.sumcheck_proof(), num_rounds)?;
 
     let zc_point = &proof.sumcheck_proof().point_var;
 
@@ -488,7 +490,9 @@ pub fn verify_split_accumulation<F: RescueParameter>(
 
     circuit.enforce_equal(initial_sumcheck_eval, sumcheck_proof.eval_var)?;
 
-    let accumulated_eval = circuit.verify_sum_check_with_challenges(sumcheck_proof)?;
+    let num_rounds = eval_points.first().unwrap().len();
+
+    let accumulated_eval = circuit.verify_sum_check_with_challenges(sumcheck_proof, num_rounds)?;
 
     let mut combiner = circuit.one();
 


### PR DESCRIPTION
Fixes https://github.com/EYBlockchain/nightfish_CE/issues/52 (Suggestion 1).
Depends on https://github.com/EYBlockchain/nightfish_CE/pull/149 to be able to access the number of rounds in the sumcheck protocol from the circuit verifying key.

The recursive prover unit test passes.