### PR TITLE
Remove unmaintained and unsound dependency

### DIFF
--- a/plonk/Cargo.toml
+++ b/plonk/Cargo.toml
@@ -56,7 +56,7 @@ ark-ed-on-bls12-377 = "0.4.0"
 ark-ed-on-bls12-381 = "0.4.0"
 ark-ed-on-bn254 = "0.4.0"
 hex = "^0.4.3"
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.7", features = ["html_reports"] }
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -73,7 +73,7 @@ ark-ed-on-bls12-377 = "0.4.0"
 ark-ed-on-bls12-381-bandersnatch = "0.4.0"
 ark-ed-on-bn254 = "0.4.0"
 bincode = "1.3"
-criterion = "0.4.0"
+criterion = "0.7.0"
 sha2 = { version = "0.10.9" }
 poseidon-rs = "0.0.8"
 ff_ce = "0.11.0"


### PR DESCRIPTION
Removes the unmaintained atty dependency which has one known vulnerability https://rustsec.org/advisories/RUSTSEC-2021-0145.

This fixes #108 suggestion 7 [PS]. The remaining unmaintained dependencies (derivative and paste) are stable, with no known vulnerabilities, so we can safely retain them.