### PR TITLE
fix(recursion): Fiat-Shamir domain initialisation

### DIFF
--- a/plonk/src/constants.rs
+++ b/plonk/src/constants.rs
@@ -6,12 +6,6 @@
 
 //! Crate wide constants.
 
-/// Proof-system-related constants.
-///
-/// label for the extra data field to be appended to the transcript during
-/// initialization
-pub(crate) const EXTRA_TRANSCRIPT_MSG_LABEL: &[u8] = b"extra info";
-
 /// Compute the ratio between the quotient polynomial domain size and
 /// the vanishing polynomial domain size
 #[inline]

--- a/plonk/src/nightfall/accumulation/circuit/atomic_gadgets.rs
+++ b/plonk/src/nightfall/accumulation/circuit/atomic_gadgets.rs
@@ -465,7 +465,7 @@ mod tests {
             _,
             _,
             RescueTranscript<FrBn254>,
-        >(&circuit, &pk)
+        >(&circuit, &pk, None)
         .unwrap()
         .0;
     }

--- a/plonk/src/nightfall/circuit/plonk_partial_verifier/scalars_and_bases.rs
+++ b/plonk/src/nightfall/circuit/plonk_partial_verifier/scalars_and_bases.rs
@@ -8,7 +8,6 @@ use jf_primitives::pcs::PolynomialCommitmentScheme;
 use jf_relation::{constants::GATE_WIDTH, gadgets::ecc::PointVariable, Circuit, PlonkCircuit};
 use jf_utils::fq_to_fr;
 
-use crate::constants::EXTRA_TRANSCRIPT_MSG_LABEL;
 use crate::errors::{PlonkError, SnarkError::ParameterError};
 use crate::nightfall::{
     circuit::plonk_partial_verifier::{
@@ -333,10 +332,11 @@ impl FFTVerifier<Kzg> {
     where
         T: Transcript,
     {
-        let mut transcript = T::new_transcript(b"PlonkProof");
-        if let Some(msg) = extra_transcript_init_msg {
-            transcript.push_message(EXTRA_TRANSCRIPT_MSG_LABEL, msg)?;
-        }
+        let mut transcript: T = if let Some(msg) = extra_transcript_init_msg {
+            T::new_with_initial_message::<_, BnConfig>(msg)?
+        } else {
+            T::new_transcript(b"PlonkProof")
+        };
 
         if let Some(vk_id) = vk_id {
             transcript.push_message(b"verifying key", vk_id)?;

--- a/plonk/src/nightfall/ipa_snark.rs
+++ b/plonk/src/nightfall/ipa_snark.rs
@@ -7,7 +7,6 @@
 //! Instantiations of Plonk-based proof systems
 
 use crate::{
-    constants::EXTRA_TRANSCRIPT_MSG_LABEL,
     errors::PlonkError,
     nightfall::{
         hops::univariate_ipa::UnivariateIpaPCS,
@@ -202,10 +201,11 @@ where
         let num_wire_types = circuits.num_wire_types();
 
         // Initialize transcript
-        let mut transcript = T::new_transcript(b"PlonkProof");
-        if let Some(msg) = extra_transcript_init_msg {
-            transcript.push_message(EXTRA_TRANSCRIPT_MSG_LABEL, &msg)?;
-        }
+        let mut transcript: T = if let Some(msg) = extra_transcript_init_msg {
+            T::new_with_initial_message::<_, P>(&msg)?
+        } else {
+            T::new_transcript(b"PlonkProof")
+        };
 
         // For FFTPlonk we only add the vk ID in the non-merged case.
         if prove_keys.vk.id.is_some() {
@@ -430,10 +430,11 @@ where
         }
 
         // Initialize transcript
-        let mut transcript = T::new_transcript(b"PlonkProof");
-        if let Some(msg) = extra_transcript_init_msg {
-            transcript.push_message(EXTRA_TRANSCRIPT_MSG_LABEL, &msg)?;
-        }
+        let mut transcript: T = if let Some(msg) = extra_transcript_init_msg {
+            T::new_with_initial_message::<_, P>(&msg)?
+        } else {
+            T::new_transcript(b"PlonkProof")
+        };
 
         // Initialize verifier challenges and online polynomial oracles.
         let mut challenges = Challenges::default();

--- a/plonk/src/nightfall/ipa_verifier.rs
+++ b/plonk/src/nightfall/ipa_verifier.rs
@@ -8,7 +8,6 @@ use super::ipa_structs::{
     eval_merged_lookup_witness, eval_merged_table, Challenges, Proof, ScalarsAndBases, VerifyingKey,
 };
 use crate::{
-    constants::EXTRA_TRANSCRIPT_MSG_LABEL,
     errors::{PlonkError, SnarkError::ParameterError},
     nightfall::ipa_structs::{MapKey, VerificationKeyId},
     transcript::*,
@@ -414,10 +413,11 @@ where
     where
         T: Transcript,
     {
-        let mut transcript = T::new_transcript(b"PlonkProof");
-        if let Some(msg) = extra_transcript_init_msg {
-            transcript.push_message(EXTRA_TRANSCRIPT_MSG_LABEL, msg)?;
-        }
+        let mut transcript: T = if let Some(msg) = extra_transcript_init_msg {
+            T::new_with_initial_message::<_, E>(msg)?
+        } else {
+            T::new_transcript(b"PlonkProof")
+        };
 
         if verify_key.id.is_some() {
             transcript.append_visitor(verify_key)?;

--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -15,7 +15,6 @@ use super::{
     UniversalSNARK,
 };
 use crate::{
-    constants::EXTRA_TRANSCRIPT_MSG_LABEL,
     errors::{PlonkError, SnarkError::ParameterError},
     proof_system::{structs::UniversalSrs, VerificationKeyId},
     transcript::*,
@@ -244,10 +243,11 @@ where
         }
 
         // Initialize transcript
-        let mut transcript = T::new_transcript(b"PlonkProof");
-        if let Some(msg) = extra_transcript_init_msg {
-            transcript.push_message(EXTRA_TRANSCRIPT_MSG_LABEL, &msg)?;
-        }
+        let mut transcript: T = if let Some(msg) = extra_transcript_init_msg {
+            T::new_with_initial_message::<_, P>(&msg)?
+        } else {
+            T::new_transcript(b"PlonkProof")
+        };
         for (pk, circuit) in prove_keys.iter().zip(circuits.iter()) {
             transcript.append_visitor(&pk.vk)?;
             for pub_input in circuit.public_input()? {

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -8,7 +8,6 @@ use super::structs::{
     BatchProof, Challenges, PlookupProof, ProofEvaluations, ScalarsAndBases, VerifyingKey,
 };
 use crate::{
-    constants::EXTRA_TRANSCRIPT_MSG_LABEL,
     errors::{PlonkError, SnarkError::ParameterError},
     proof_system::structs::{eval_merged_lookup_witness, eval_merged_table, OpenKey},
     transcript::*,
@@ -309,10 +308,11 @@ where
             ))
             .into());
         }
-        let mut transcript = T::new_transcript(b"PlonkProof");
-        if let Some(msg) = extra_transcript_init_msg {
-            transcript.push_message(EXTRA_TRANSCRIPT_MSG_LABEL, msg)?;
-        }
+        let mut transcript: T = if let Some(msg) = extra_transcript_init_msg {
+            T::new_with_initial_message::<_, P>(msg)?
+        } else {
+            T::new_transcript(b"PlonkProof")
+        };
         for (&vk, &pi) in verify_keys.iter().zip(public_inputs.iter()) {
             transcript.append_visitor(vk)?;
             for pub_input in pi.iter() {

--- a/plonk/src/recursion/circuits/challenges.rs
+++ b/plonk/src/recursion/circuits/challenges.rs
@@ -127,6 +127,7 @@ pub fn reconstruct_mle_challenges<P, F, PCS, Scheme, T, C>(
     proof_var: &SAMLEProofVar<PCS>,
     circuit: &mut PlonkCircuit<F>,
     pi_hash: &EmulatedVariable<P::ScalarField>,
+    initialisation_msg: &Option<Vec<u8>>,
 ) -> Result<(MLEProofChallenges<P::ScalarField>, C), CircuitError>
 where
     PCS: Accumulation<
@@ -143,7 +144,11 @@ where
     C: CircuitTranscript<F>,
 {
     // First lets instantiate the transcript and make the variable version of the proof and pi_commitment.
-    let mut transcript = C::new_transcript(circuit);
+    let mut transcript: C = if let Some(msg) = initialisation_msg {
+        C::new_with_initial_message::<_, P>(msg, circuit)?
+    } else {
+        C::new_transcript(circuit)
+    };
 
     // Now we begin by recovering the circuit version of the MLEChallenges struct.
     let mle_challenges =

--- a/plonk/src/recursion/circuits/mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/mle_arithmetic.rs
@@ -787,6 +787,7 @@ mod tests {
                 &_vk1,
                 public_input[0],
                 rng,
+                None,
             )
             .unwrap();
 
@@ -936,16 +937,17 @@ mod tests {
                         .unwrap();
                     let proof_var =
                         SAMLEProofVar::from_struct(&mut challenges_circuit, &output.proof).unwrap();
-                    let (stuff, _) =
-                        reconstruct_mle_challenges::<
-                            _,
-                            _,
-                            Zmorph,
-                            MLEPlonk<Zmorph>,
-                            RescueTranscript<Fr254>,
-                            RescueTranscriptVar<Fr254>,
-                        >(&proof_var, &mut challenges_circuit, &pi_hash)
-                        .unwrap();
+                    let (stuff, _) = reconstruct_mle_challenges::<
+                        _,
+                        _,
+                        Zmorph,
+                        MLEPlonk<Zmorph>,
+                        RescueTranscript<Fr254>,
+                        RescueTranscriptVar<Fr254>,
+                    >(
+                        &proof_var, &mut challenges_circuit, &pi_hash, &None
+                    )
+                    .unwrap();
                     stuff
                 })
                 .collect::<Vec<MLEProofChallenges<Fq254>>>();

--- a/plonk/src/recursion/fs_domain.rs
+++ b/plonk/src/recursion/fs_domain.rs
@@ -1,0 +1,66 @@
+//! Helpers for building Fiat-Shamir domain separation messages for recursive proving.
+
+use ark_serialize::CanonicalSerialize;
+use ark_std::vec::Vec;
+use sha2::{Digest, Sha256};
+
+/// Stable, deterministic 32-byte hash helper
+fn h256(bytes: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(bytes));
+    out
+}
+
+/// Canonical-serialize and hash a value (VK, SRS bits, etc.)
+pub fn hash_canonical<T: CanonicalSerialize>(x: &T) -> [u8; 32] {
+    let mut buf = Vec::new();
+    x.serialize_compressed(&mut buf).unwrap();
+    h256(&buf)
+}
+
+/// Build a fixed-order, length-prefixed FS init message.
+/// Use a simple TLV-ish format to avoid JSON/non-determinism.
+#[allow(clippy::too_many_arguments)]
+pub fn fs_domain_bytes(
+    app_id: &'static str,
+    proto: &'static str,
+    version: &'static str,
+    role: &'static str,   // e.g. "rollup_prover"
+    layer: &'static str,  // e.g. "base_bn254" | "merge_grumpkin" | "decider"
+    vk_digest: [u8; 32],  // hash_canonical(&vk)
+    srs_digest: [u8; 32], // KZG/IPA SRS digest
+    recursion_depth: u32, // 0 at base, then increment upwards
+    rollup_size: u32,     // number of leaf proofs in this batch
+) -> Vec<u8> {
+    let mut msg = Vec::new();
+    let push = |m: &mut Vec<u8>, label: &str, v: &[u8]| {
+        m.extend_from_slice(&(label.len() as u32).to_be_bytes());
+        m.extend_from_slice(label.as_bytes());
+        m.extend_from_slice(&(v.len() as u32).to_be_bytes());
+        m.extend_from_slice(v);
+    };
+    push(&mut msg, "app_id", app_id.as_bytes());
+    push(&mut msg, "proto", proto.as_bytes());
+    push(&mut msg, "version", version.as_bytes());
+    push(&mut msg, "role", role.as_bytes());
+    push(&mut msg, "layer", layer.as_bytes());
+    push(&mut msg, "vk_digest", &vk_digest);
+    push(&mut msg, "srs_digest", &srs_digest);
+    push(&mut msg, "recursion_depth", &recursion_depth.to_be_bytes());
+    push(&mut msg, "rollup_size", &rollup_size.to_be_bytes());
+    msg
+}
+
+/// Deterministic ChaCha seed from FS domain msg
+pub fn rng_seed_from_fs(fs_msg: &[u8]) -> [u8; 32] {
+    h256(&[fs_msg].concat())
+}
+
+#[derive(Clone, Debug)]
+#[allow(missing_docs)]
+/// Struct for FS initialization message metadata.
+pub struct FSInitMetadata {
+    pub recursion_depth: usize,
+    pub rollup_size: u32,
+    pub srs_digest: [u8; 32],
+}

--- a/plonk/src/transcript/mod.rs
+++ b/plonk/src/transcript/mod.rs
@@ -34,6 +34,14 @@ pub trait Transcript {
     /// Create a new plonk transcript.
     fn new_transcript(label: &'static [u8]) -> Self;
 
+    /// Create a new plonk transcript with an initial message.
+    fn new_with_initial_message<S, E>(msg: &S) -> Result<Self, PlonkError>
+    where
+        Self: Sized,
+        S: CanonicalSerialize + ?Sized + 'static,
+        E: HasTEForm,
+        E::BaseField: PrimeField;
+
     /// Append a serializable message to the transcript.
     /// The message is serialized using `CanonicalSerialize`.
     fn push_message<S: CanonicalSerialize + ?Sized + 'static>(
@@ -114,6 +122,29 @@ pub trait Transcript {
 pub trait CircuitTranscript<F: PrimeField> {
     /// Create a new circuit transcript.
     fn new_transcript(circuit: &mut PlonkCircuit<F>) -> Self;
+
+    /// Create a new plonk transcript with an initial message.
+    fn new_with_initial_message<S, E>(
+        msg: &S,
+        circuit: &mut PlonkCircuit<F>,
+    ) -> Result<Self, PlonkError>
+    where
+        Self: Sized,
+        S: CanonicalSerialize + ?Sized + 'static,
+        E: HasTEForm,
+        E::BaseField: PrimeField;
+
+    /// Append a serializable message to the transcript.
+    /// The message is serialized using `CanonicalSerialize`.
+    fn push_message<S: CanonicalSerialize + ?Sized + 'static, E>(
+        &mut self,
+        label: &'static [u8],
+        msg: &S,
+        circuit: &mut PlonkCircuit<F>,
+    ) -> Result<(), PlonkError>
+    where
+        E: HasTEForm,
+        E::BaseField: PrimeField;
 
     /// Append a variable to the transcript
     fn push_variable(&mut self, var: &Variable) -> Result<(), CircuitError>;

--- a/plonk/src/transcript/solidity.rs
+++ b/plonk/src/transcript/solidity.rs
@@ -44,6 +44,18 @@ impl Transcript for SolidityTranscript {
         }
     }
 
+    fn new_with_initial_message<S, E>(msg: &S) -> Result<Self, PlonkError>
+    where
+        Self: Sized,
+        S: CanonicalSerialize + ?Sized + 'static,
+        E: HasTEForm,
+        E::BaseField: PrimeField,
+    {
+        let mut transcript = Self::new_transcript(b"");
+        transcript.push_message(b"", msg)?;
+        Ok(transcript)
+    }
+
     fn push_message<S: CanonicalSerialize + ?Sized + 'static>(
         &mut self,
         _label: &'static [u8],

--- a/plonk/src/transcript/standard.rs
+++ b/plonk/src/transcript/standard.rs
@@ -22,6 +22,18 @@ impl TranscriptTrait for StandardTranscript {
         Self(Transcript::new(label))
     }
 
+    fn new_with_initial_message<S, E>(msg: &S) -> Result<Self, PlonkError>
+    where
+        Self: Sized,
+        S: CanonicalSerialize + ?Sized + 'static,
+        E: HasTEForm,
+        E::BaseField: PrimeField,
+    {
+        let mut transcript = Self::new_transcript(b"");
+        transcript.push_message(b"", msg)?;
+        Ok(transcript)
+    }
+
     fn push_message<S: CanonicalSerialize + ?Sized + 'static>(
         &mut self,
         label: &'static [u8],


### PR DESCRIPTION
Fixes issue Z [PS]. We do not include the public inputs hash as it is already included into the transcript as a public input. NF4-side changes to follow. It passes the recursive prover unit test.