### PR TITLE
Allow grumpkin accs to grow by more than one

### DIFF
--- a/plonk/src/recursion/merge_functions.rs
+++ b/plonk/src/recursion/merge_functions.rs
@@ -307,7 +307,7 @@ impl GrumpkinRecursiveInfo {
                     proof_num_vars,
                     evals,
                 ));
-                acc.point.push(Fq254::zero());
+                acc.point.resize(proof_num_vars, Fq254::zero());
             });
         }
         let transcript_accumulators = [ta0, ta1, ta2, ta3, ta4, ta5, ta6, ta7];


### PR DESCRIPTION
This very small PR fixes a bug that only allowed grumpkin circuits to increase by at most one power of 2 between consecutive grumpkin layers. Theoretically, now they can increase in size by an arbitrary amount.