### PR TITLE
jf_primitives/pcs: expose SRS sha256 digest in prelude

### DIFF
--- a/primitives/src/pcs/prelude.rs
+++ b/primitives/src/pcs/prelude.rs
@@ -8,6 +8,7 @@
 pub use crate::pcs::{
     errors::PCSError,
     univariate_kzg::{
+        ptau_digests::expected_sha256_for_label,
         srs::{UnivariateProverParam, UnivariateUniversalParams, UnivariateVerifierParam},
         UnivariateKzgBatchProof, UnivariateKzgPCS, UnivariateKzgProof,
     },

--- a/primitives/src/pcs/univariate_kzg/ptau_digests.rs
+++ b/primitives/src/pcs/univariate_kzg/ptau_digests.rs
@@ -249,6 +249,7 @@ pub const PSE_PPOT_SHA256: &[(&str, &str)] = &[
     // ("final", "PLACEHOLDER_FOR_FINAL"), // Placeholder, replace with actual hash if needed
 ];
 
+/// Returns the sha256 digest for the SRS with length 2^{label}
 pub fn expected_sha256_for_label(label: &str) -> Option<&'static str> {
     PSE_PPOT_SHA256
         .iter()


### PR DESCRIPTION
We expose the SRS digest function in the prelude to access it from Nightfall.