### PR TITLE
Livesey/mle fiat shamir

### DIFF
--- a/plonk/src/nightfall/circuit/plonk_partial_verifier/gadgets.rs
+++ b/plonk/src/nightfall/circuit/plonk_partial_verifier/gadgets.rs
@@ -807,11 +807,6 @@ mod test {
                 mle_challenges.tau,
                 plonk_circuit.emulated_witness(&mle_challenges_var.tau)?
             );
-
-            assert_eq!(
-                mle_challenges.delta,
-                plonk_circuit.emulated_witness(&mle_challenges_var.delta)?
-            );
         }
         Ok(())
     }

--- a/plonk/src/nightfall/circuit/plonk_partial_verifier/structs.rs
+++ b/plonk/src/nightfall/circuit/plonk_partial_verifier/structs.rs
@@ -31,8 +31,8 @@ use crate::{
         hops::srs::UnivariateUniversalIpaParams,
         ipa_structs::{Challenges as PCSChallenges, PlookupProof, Proof as PCSProof},
         mle::mle_structs::{
-            MLEChallenges, MLELookupEvals, MLELookupProof, MLEProofEvals, MLEVerifyingKey,
-            SAMLEProof,
+            FullMLEChallenges, MLEChallenges, MLELookupEvals, MLELookupProof, MLEProofEvals,
+            MLEVerifyingKey, SAMLEProof,
         },
     },
     proof_system::structs::{PlookupEvaluations, ProofEvaluations},
@@ -175,8 +175,6 @@ pub struct EmulatedMLEChallenges<E: PrimeField> {
     pub(crate) alpha: EmulatedVariable<E>,
     pub(crate) tau: EmulatedVariable<E>,
     pub(crate) beta: EmulatedVariable<E>,
-    pub(crate) delta: EmulatedVariable<E>,
-    pub(crate) epsilon: EmulatedVariable<E>,
 }
 
 impl<E: PrimeField> EmulatedMLEChallenges<E> {
@@ -186,16 +184,12 @@ impl<E: PrimeField> EmulatedMLEChallenges<E> {
         alpha: EmulatedVariable<E>,
         tau: EmulatedVariable<E>,
         beta: EmulatedVariable<E>,
-        delta: EmulatedVariable<E>,
-        epsilon: EmulatedVariable<E>,
     ) -> Self {
         Self {
             gamma,
             alpha,
             tau,
             beta,
-            delta,
-            epsilon,
         }
     }
 
@@ -213,10 +207,8 @@ impl<E: PrimeField> EmulatedMLEChallenges<E> {
         let alpha = circuit.create_emulated_variable(challenges.alpha)?;
         let tau = circuit.create_emulated_variable(challenges.tau)?;
         let beta = circuit.create_emulated_variable(challenges.beta)?;
-        let delta = circuit.create_emulated_variable(challenges.delta)?;
-        let epsilon = circuit.create_emulated_variable(challenges.epsilon)?;
 
-        Ok(Self::new(gamma, alpha, tau, beta, delta, epsilon))
+        Ok(Self::new(gamma, alpha, tau, beta))
     }
 
     /// Computes challenges from a proof.
@@ -251,31 +243,75 @@ impl<E: PrimeField> EmulatedMLEChallenges<E> {
             transcript_var.append_point_variable(&lookup_proof_var.m_poly_comm_var, circuit)?;
         }
 
-        let [alpha, beta, delta, epsilon]: [usize; 4] = transcript_var
-            .squeeze_scalar_challenges::<P>(4, circuit)?
+        let [alpha, beta]: [usize; 2] = transcript_var
+            .squeeze_scalar_challenges::<P>(2, circuit)?
             .try_into()
             .map_err(|_| {
                 CircuitError::ParameterError("Could not convert to fixed length array".to_string())
             })?;
         let alpha_var = circuit.to_emulated_variable(alpha)?;
         let beta_var = circuit.to_emulated_variable(beta)?;
-        let delta_var = circuit.to_emulated_variable(delta)?;
-        let epsilon_var = circuit.to_emulated_variable(epsilon)?;
-        Ok(Self::new(
-            gamma_var,
-            alpha_var,
-            tau_var,
-            beta_var,
-            delta_var,
-            epsilon_var,
-        ))
+        Ok(Self::new(gamma_var, alpha_var, tau_var, beta_var))
+    }
+}
+
+/// Struct used to represent [`FullMLEChallenges`] as [`EmulatedVariable`]s.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct EmulatedFullMLEChallenges<E: PrimeField> {
+    pub(crate) gamma: EmulatedVariable<E>,
+    pub(crate) alpha: EmulatedVariable<E>,
+    pub(crate) tau: EmulatedVariable<E>,
+    pub(crate) beta: EmulatedVariable<E>,
+    pub(crate) delta: EmulatedVariable<E>,
+    pub(crate) epsilon: EmulatedVariable<E>,
+}
+
+impl<E: PrimeField> EmulatedFullMLEChallenges<E> {
+    /// Create a new [`EmulatedFullMLEChallenges`].
+    pub fn new(
+        gamma: EmulatedVariable<E>,
+        alpha: EmulatedVariable<E>,
+        tau: EmulatedVariable<E>,
+        beta: EmulatedVariable<E>,
+        delta: EmulatedVariable<E>,
+        epsilon: EmulatedVariable<E>,
+    ) -> Self {
+        Self {
+            gamma,
+            alpha,
+            tau,
+            beta,
+            delta,
+            epsilon,
+        }
+    }
+
+    /// Create a new [`EmulatedMLEChallenges`] variable from a reference to a [`MLEChallenges`].
+    pub fn from_struct<P>(
+        circuit: &mut PlonkCircuit<P::BaseField>,
+        challenges: &FullMLEChallenges<P::ScalarField>,
+    ) -> Result<Self, CircuitError>
+    where
+        P: HasTEForm<ScalarField = E>,
+        P::BaseField: PrimeField + EmulationConfig<P::ScalarField> + RescueParameter,
+        P::ScalarField: PrimeField + EmulationConfig<P::BaseField> + RescueParameter,
+    {
+        let gamma = circuit.create_emulated_variable(challenges.gamma)?;
+        let alpha = circuit.create_emulated_variable(challenges.alpha)?;
+        let tau = circuit.create_emulated_variable(challenges.tau)?;
+        let beta = circuit.create_emulated_variable(challenges.beta)?;
+        let delta = circuit.create_emulated_variable(challenges.delta)?;
+        let epsilon = circuit.create_emulated_variable(challenges.epsilon)?;
+
+        Ok(Self::new(gamma, alpha, tau, beta, delta, epsilon))
     }
 
     /// Reconstruct a concrete `MLEChallenges` from the emulated variables.
     pub fn to_struct<P>(
         &self,
         circuit: &mut PlonkCircuit<P::BaseField>,
-    ) -> Result<MLEChallenges<P::ScalarField>, CircuitError>
+    ) -> Result<FullMLEChallenges<P::ScalarField>, CircuitError>
     where
         P: HasTEForm<ScalarField = E>,
         P::BaseField: PrimeField + EmulationConfig<P::ScalarField> + RescueParameter,
@@ -290,7 +326,7 @@ impl<E: PrimeField> EmulatedMLEChallenges<E> {
         let delta = read(&self.delta)?;
         let epsilon = read(&self.epsilon)?;
 
-        Ok(MLEChallenges {
+        Ok(FullMLEChallenges {
             gamma,
             alpha,
             tau,
@@ -298,6 +334,22 @@ impl<E: PrimeField> EmulatedMLEChallenges<E> {
             delta,
             epsilon,
         })
+    }
+
+    /// Creates a new [`EmulatedFullMLEChallenges`] from [`EmulatedMLEChallenges`] and delta, epsilon variables.
+    pub fn from_parts(
+        emulated_mle_challenges: &EmulatedMLEChallenges<E>,
+        delta: &EmulatedVariable<E>,
+        epsilon: &EmulatedVariable<E>,
+    ) -> Self {
+        Self::new(
+            emulated_mle_challenges.gamma.clone(),
+            emulated_mle_challenges.alpha.clone(),
+            emulated_mle_challenges.tau.clone(),
+            emulated_mle_challenges.beta.clone(),
+            delta.clone(),
+            epsilon.clone(),
+        )
     }
 }
 
@@ -308,11 +360,114 @@ pub struct MLEChallengesVar {
     pub(crate) alpha: Variable,
     pub(crate) tau: Variable,
     pub(crate) beta: Variable,
+}
+
+impl MLEChallengesVar {
+    /// Create a new [`MLEChallengesVar`].
+    pub fn new(gamma: Variable, alpha: Variable, tau: Variable, beta: Variable) -> Self {
+        Self {
+            gamma,
+            alpha,
+            tau,
+            beta,
+        }
+    }
+
+    /// Create a new [`MLEChallengesNative`] variable from a reference to a [`MLEChallenges`].
+    pub fn from_struct<F>(
+        circuit: &mut PlonkCircuit<F>,
+        challenges: &MLEChallenges<F>,
+    ) -> Result<Self, CircuitError>
+    where
+        F: PrimeField,
+    {
+        let gamma = circuit.create_variable(challenges.gamma)?;
+        let alpha = circuit.create_variable(challenges.alpha)?;
+        let tau = circuit.create_variable(challenges.tau)?;
+        let beta = circuit.create_variable(challenges.beta)?;
+
+        Ok(Self::new(gamma, alpha, tau, beta))
+    }
+
+    /// Computes challenges from a proof.
+    pub fn compute_challenges<PCS, P, F, C>(
+        circuit: &mut PlonkCircuit<F>,
+        pi_hash: &EmulatedVariable<P::ScalarField>,
+        proof_var: &SAMLEProofVar<PCS>,
+        transcript_var: &mut C,
+    ) -> Result<Self, CircuitError>
+    where
+        PCS: PolynomialCommitmentScheme<Commitment = Affine<P>, Evaluation = P::ScalarField>,
+        P: HasTEForm<BaseField = F>,
+        P::BaseField: PrimeField + RescueParameter,
+        P::ScalarField: PrimeField + RescueParameter + EmulationConfig<F>,
+        F: PrimeField + RescueParameter,
+        C: CircuitTranscript<F>,
+    {
+        transcript_var.push_emulated_variable(pi_hash, circuit)?;
+        transcript_var.append_point_variables(&proof_var.wire_commitments_var, circuit)?;
+
+        let [gamma, tau]: [usize; 2] = transcript_var
+            .squeeze_scalar_challenges::<P>(2, circuit)?
+            .try_into()
+            .map_err(|_| {
+                CircuitError::ParameterError("Could not convert to fixed length array".to_string())
+            })?;
+
+        if let Some(lookup_proof_var) = proof_var.lookup_proof_var.as_ref() {
+            transcript_var.append_point_variable(&lookup_proof_var.m_poly_comm_var, circuit)?;
+        }
+
+        let [alpha, beta]: [usize; 2] = transcript_var
+            .squeeze_scalar_challenges::<P>(2, circuit)?
+            .try_into()
+            .map_err(|_| {
+                CircuitError::ParameterError("Could not convert to fixed length array".to_string())
+            })?;
+
+        Ok(Self::new(gamma, alpha, tau, beta))
+    }
+
+    /// Exposes the challenges as public inputs to the circuit.
+    pub fn set_public<F>(&self, circuit: &mut PlonkCircuit<F>) -> Result<(), CircuitError>
+    where
+        F: PrimeField,
+    {
+        circuit.set_variable_public(self.gamma)?;
+        circuit.set_variable_public(self.alpha)?;
+        circuit.set_variable_public(self.tau)?;
+        circuit.set_variable_public(self.beta)
+    }
+
+    /// Converts the challenges to field elements.
+    pub fn to_field<F>(
+        &self,
+        circuit: &mut PlonkCircuit<F>,
+    ) -> Result<MLEChallenges<F>, CircuitError>
+    where
+        F: PrimeField,
+    {
+        Ok(MLEChallenges {
+            gamma: circuit.witness(self.gamma)?,
+            alpha: circuit.witness(self.alpha)?,
+            tau: circuit.witness(self.tau)?,
+            beta: circuit.witness(self.beta)?,
+        })
+    }
+}
+
+/// Struct use to represent [`MLEChallenges`] as [`Variable`]s over the native field.
+#[derive(Debug, Clone, Copy)]
+pub struct FullMLEChallengesVar {
+    pub(crate) gamma: Variable,
+    pub(crate) alpha: Variable,
+    pub(crate) tau: Variable,
+    pub(crate) beta: Variable,
     pub(crate) delta: Variable,
     pub(crate) epsilon: Variable,
 }
 
-impl MLEChallengesVar {
+impl FullMLEChallengesVar {
     /// Create a new [`MLEChallengesVar`].
     pub fn new(
         gamma: Variable,
@@ -332,10 +487,10 @@ impl MLEChallengesVar {
         }
     }
 
-    /// Create a new [`MLEChallengesNative`] variable from a reference to a [`MLEChallenges`].
+    /// Create a new [`FullMLEChallengesVar`] variable from a reference to a [`FullMLEChallenges`].
     pub fn from_struct<F>(
         circuit: &mut PlonkCircuit<F>,
-        challenges: &MLEChallenges<F>,
+        challenges: &FullMLEChallenges<F>,
     ) -> Result<Self, CircuitError>
     where
         F: PrimeField,
@@ -350,74 +505,20 @@ impl MLEChallengesVar {
         Ok(Self::new(gamma, alpha, tau, beta, delta, epsilon))
     }
 
-    /// Computes challenges from a proof.
-    pub fn compute_challenges<PCS, P, F, C>(
-        circuit: &mut PlonkCircuit<F>,
-        pi_hash: &EmulatedVariable<P::ScalarField>,
-        proof_var: &SAMLEProofVar<PCS>,
-        transcript_var: &mut C,
-    ) -> Result<Self, CircuitError>
-    where
-        PCS: PolynomialCommitmentScheme<Commitment = Affine<P>, Evaluation = P::ScalarField>,
-        P: HasTEForm,
-        P::BaseField: PrimeField + RescueParameter,
-        P::ScalarField: PrimeField + RescueParameter + EmulationConfig<F>,
-        F: PrimeField,
-        C: CircuitTranscript<F>,
-    {
-        transcript_var.push_emulated_variable(pi_hash, circuit)?;
-        transcript_var.append_point_variables(&proof_var.wire_commitments_var, circuit)?;
-
-        let [gamma, tau]: [usize; 2] = transcript_var
-            .squeeze_scalar_challenges::<P>(2, circuit)?
-            .try_into()
-            .map_err(|_| {
-                CircuitError::ParameterError("Could not convert to fixed length array".to_string())
-            })?;
-
-        if let Some(lookup_proof_var) = proof_var.lookup_proof_var.as_ref() {
-            transcript_var.append_point_variable(&lookup_proof_var.m_poly_comm_var, circuit)?;
-        }
-
-        let [alpha, beta, delta, epsilon]: [usize; 4] = transcript_var
-            .squeeze_scalar_challenges::<P>(4, circuit)?
-            .try_into()
-            .map_err(|_| {
-                CircuitError::ParameterError("Could not convert to fixed length array".to_string())
-            })?;
-
-        Ok(Self::new(gamma, alpha, tau, beta, delta, epsilon))
-    }
-
-    /// Exposes the challenges as public inputs to the circuit.
-    pub fn set_public<F>(&self, circuit: &mut PlonkCircuit<F>) -> Result<(), CircuitError>
-    where
-        F: PrimeField,
-    {
-        circuit.set_variable_public(self.gamma)?;
-        circuit.set_variable_public(self.alpha)?;
-        circuit.set_variable_public(self.tau)?;
-        circuit.set_variable_public(self.beta)?;
-        circuit.set_variable_public(self.delta)?;
-        circuit.set_variable_public(self.epsilon)
-    }
-
-    /// Converts the challenges to field elements.
-    pub fn to_field<F>(
-        &self,
-        circuit: &mut PlonkCircuit<F>,
-    ) -> Result<MLEChallenges<F>, CircuitError>
-    where
-        F: PrimeField,
-    {
-        Ok(MLEChallenges {
-            gamma: circuit.witness(self.gamma)?,
-            alpha: circuit.witness(self.alpha)?,
-            tau: circuit.witness(self.tau)?,
-            beta: circuit.witness(self.beta)?,
-            delta: circuit.witness(self.delta)?,
-            epsilon: circuit.witness(self.epsilon)?,
-        })
+    /// Creates a new [`FullMLEChallengesVar`] from [`MLEChallengesVar`] and delta, epsilon variables.
+    pub fn from_parts(
+        mle_challenges_var: &MLEChallengesVar,
+        delta: Variable,
+        epsilon: Variable,
+    ) -> Self {
+        Self::new(
+            mle_challenges_var.gamma,
+            mle_challenges_var.alpha,
+            mle_challenges_var.tau,
+            mle_challenges_var.beta,
+            delta,
+            epsilon,
+        )
     }
 }
 

--- a/plonk/src/nightfall/mle/snark.rs
+++ b/plonk/src/nightfall/mle/snark.rs
@@ -31,7 +31,7 @@ use crate::{
     errors::{PlonkError, SnarkError},
     nightfall::{
         accumulation::{accumulation_structs::SplitAccumulator, MLAccumulator},
-        mle::mle_structs::MLEProofShared,
+        mle::mle_structs::{FullMLEChallenges, MLEProofShared},
     },
     proof_system::RecursiveOutput,
     transcript::Transcript,
@@ -261,7 +261,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         let mut gkr_q_polys = vec![perm_q_poly];
 
         // Run the lookup related subroutines if support lookup.
-        let (m_poly, m_commit, [alpha, beta, delta, epsilon]) = if pk.lookup_proving_key.is_some() {
+        let (m_poly, m_commit, [alpha, beta]) = if pk.lookup_proving_key.is_some() {
             let lookup_table = circuit.compute_merged_lookup_table_mle(tau)?;
             let lookup_wire = circuit.compute_lookup_sorted_vec_mles(tau, &lookup_table)?;
             let table = Arc::new(DenseMultilinearExtension::from_evaluations_vec(
@@ -273,8 +273,8 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             let m_commit = PCS::commit(&pk.pcs_prover_params, &m_poly)?;
 
             transcript.append_curve_point(b"m_commit", &m_commit)?;
-            let [alpha, beta, delta, epsilon]: [P::ScalarField; 4] = transcript
-                .squeeze_scalar_challenges::<P>(b"alpha beta delta epsilon", 4)?
+            let [alpha, beta]: [P::ScalarField; 2] = transcript
+                .squeeze_scalar_challenges::<P>(b"alpha beta", 2)?
                 .try_into()
                 .map_err(|_| {
                     PlonkError::InvalidParameters(
@@ -287,17 +287,17 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
 
             gkr_p_polys.push(prepped_items.p_poly);
             gkr_q_polys.push(prepped_items.q_poly);
-            (Some(m_poly), Some(m_commit), [alpha, beta, delta, epsilon])
+            (Some(m_poly), Some(m_commit), [alpha, beta])
         } else {
-            let [alpha, beta, delta, epsilon]: [P::ScalarField; 4] = transcript
-                .squeeze_scalar_challenges::<P>(b"alpha beta delta epsilon", 4)?
+            let [alpha, beta]: [P::ScalarField; 2] = transcript
+                .squeeze_scalar_challenges::<P>(b"alpha beta", 2)?
                 .try_into()
                 .map_err(|_| {
                     PlonkError::InvalidParameters(
                         "Couldn't convert to fixed length array".to_string(),
                     )
                 })?;
-            (None, None, [alpha, beta, delta, epsilon])
+            (None, None, [alpha, beta])
         };
         let gkr_proof = batch_prove_gkr::<P, _>(&gkr_p_polys, &gkr_q_polys, &mut transcript)?;
         // Now we have done the GKR proof we run a final zero check on the underlying products of MLEs.
@@ -312,9 +312,10 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             gamma,
             alpha,
             tau,
-            delta,
-            epsilon,
         };
+
+        let epsilon = transcript.squeeze_scalar_challenge::<P>(b"epsilon")?;
+
         let sumcheck_vp = build_sumcheck_poly(
             &wire_polys,
             &pk.selector_oracles,
@@ -323,6 +324,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             eq_poly.clone(),
             &pk.verifying_key.gate_info,
             &challenges,
+            epsilon,
             pk.lookup_proving_key.as_ref(),
             m_poly.clone(),
         )?;
@@ -530,6 +532,8 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             None
         };
 
+        let delta = transcript.squeeze_scalar_challenge::<P>(b"delta")?;
+
         let mut combiner = P::ScalarField::one();
         let batched_poly_evals = pcs_accumulator.polynomials().iter().try_fold(
             vec![P::ScalarField::zero(); 1 << num_vars],
@@ -629,7 +633,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         let mut gkr_q_polys = vec![perm_q_poly.clone()];
 
         // Run the lookup related subroutines if support lookup.
-        let (m_poly, m_commit, [alpha, beta, delta, epsilon]) = if pk.lookup_proving_key.is_some() {
+        let (m_poly, m_commit, [alpha, beta]) = if pk.lookup_proving_key.is_some() {
             let lookup_table = circuit.compute_merged_lookup_table_mle(tau)?;
             let lookup_wire = circuit.compute_lookup_sorted_vec_mles(tau, &lookup_table)?;
             let table = Arc::new(DenseMultilinearExtension::from_evaluations_vec(
@@ -641,8 +645,8 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             let m_commit = PCS::commit(&pk.pcs_prover_params, &m_poly)?;
 
             transcript.append_curve_point(b"m_commit", &m_commit)?;
-            let [alpha, beta, delta, epsilon]: [P::ScalarField; 4] = transcript
-                .squeeze_scalar_challenges::<P>(b"alpha beta delta epsilon", 4)?
+            let [alpha, beta]: [P::ScalarField; 2] = transcript
+                .squeeze_scalar_challenges::<P>(b"alpha beta", 2)?
                 .try_into()
                 .map_err(|_| {
                     PlonkError::InvalidParameters(
@@ -655,22 +659,24 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
 
             gkr_p_polys.push(prepped_items.p_poly);
             gkr_q_polys.push(prepped_items.q_poly);
-            (Some(m_poly), Some(m_commit), [alpha, beta, delta, epsilon])
+            (Some(m_poly), Some(m_commit), [alpha, beta])
         } else {
-            let [alpha, beta, delta, epsilon]: [P::ScalarField; 4] = transcript
-                .squeeze_scalar_challenges::<P>(b"alpha beta delta epsilon", 4)?
+            let [alpha, beta]: [P::ScalarField; 2] = transcript
+                .squeeze_scalar_challenges::<P>(b"alpha beta", 2)?
                 .try_into()
                 .map_err(|_| {
                     PlonkError::InvalidParameters(
                         "Couldn't convert to fixed length array".to_string(),
                     )
                 })?;
-            (None, None, [alpha, beta, delta, epsilon])
+            (None, None, [alpha, beta])
         };
 
         let gkr_proof = batch_prove_gkr::<P, _>(&gkr_p_polys, &gkr_q_polys, &mut transcript)?;
 
         // Now we have done the GKR proof we run a final zero check on the underlying products of MLEs.
+        let epsilon = transcript.squeeze_scalar_challenge::<P>(b"epsilon")?;
+
         let gkr_point = &gkr_proof.sumcheck_proofs.last().as_ref().unwrap().point;
 
         let eq_poly = Arc::new(build_eq_x_r(gkr_point));
@@ -679,8 +685,6 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             gamma,
             alpha,
             tau,
-            delta,
-            epsilon,
         };
 
         let sumcheck_vp = build_sumcheck_poly(
@@ -691,6 +695,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             eq_poly.clone(),
             &pk.verifying_key.gate_info,
             &challenges,
+            epsilon,
             pk.lookup_proving_key.as_ref(),
             m_poly.clone(),
         )?;
@@ -796,6 +801,8 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
             permutation_evals,
         };
 
+        let delta = transcript.squeeze_scalar_challenge::<P>(b"delta")?;
+
         let (_, poly_evals) = combiner_set.iter().try_fold(
             (
                 P::ScalarField::one(),
@@ -882,29 +889,31 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         // gkr_evals[7] = (beta * alpha - beta * lookup_table)
         let gkr_evals = gkr_deferred_check.evals();
 
+        let epsilon = transcript.squeeze_scalar_challenge::<P>(b"epsilon")?;
+
         let initial_sumcheck_eval = if gkr_evals.len() == 8 {
             let mut combiner = P::ScalarField::one();
             let perm_eval = gkr_evals[..4]
                 .iter()
                 .fold(P::ScalarField::zero(), |acc, eval| {
-                    combiner *= challenges.epsilon;
+                    combiner *= epsilon;
                     acc + *eval * combiner
                 });
 
-            combiner *= challenges.epsilon;
+            combiner *= epsilon;
             combiner /= challenges.beta;
             let beta_alpha = challenges.beta * challenges.alpha;
             perm_eval
                 + combiner
                     * ((beta_alpha - gkr_evals[6])
-                        + challenges.epsilon * (beta_alpha - gkr_evals[7])
-                        + challenges.epsilon * challenges.epsilon * gkr_evals[5])
+                        + epsilon * (beta_alpha - gkr_evals[7])
+                        + epsilon * epsilon * gkr_evals[5])
         } else if gkr_evals.len() == 4 {
             let mut combiner = P::ScalarField::one();
             gkr_evals[..4]
                 .iter()
                 .fold(P::ScalarField::zero(), |acc, eval| {
-                    combiner *= challenges.epsilon;
+                    combiner *= epsilon;
                     acc + *eval * combiner
                 })
         } else {
@@ -934,6 +943,10 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
                     "Could not evaluate pi poly".to_string(),
                 ))?;
 
+        let delta = transcript.squeeze_scalar_challenge::<P>(b"delta")?;
+
+        let full_challenges = FullMLEChallenges::from_parts(challenges, delta, epsilon);
+
         let zero_check_calc_eval = build_zerocheck_eval(
             &proof.evals,
             proof
@@ -941,7 +954,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
                 .as_ref()
                 .map(|lookup_proof| &lookup_proof.lookup_evals),
             &vk.gate_info,
-            &challenges,
+            &full_challenges,
             pi_poly_eval,
             zc_eq_eval,
         );
@@ -1015,7 +1028,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         }
 
         let delta_powers = (0..comms.len() as u64)
-            .map(|i| challenges.delta.pow([i]))
+            .map(|i| delta.pow([i]))
             .collect::<Vec<P::ScalarField>>();
 
         let eval = evals
@@ -1106,29 +1119,31 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         // gkr_evals[7] = (beta * alpha - beta * lookup_table)
         let gkr_evals = gkr_deferred_check.evals();
 
+        let epsilon = transcript.squeeze_scalar_challenge::<P>(b"epsilon")?;
+
         let initial_sumcheck_eval = if gkr_evals.len() == 8 {
             let mut combiner = P::ScalarField::one();
             let perm_eval = gkr_evals[..4]
                 .iter()
                 .fold(P::ScalarField::zero(), |acc, eval| {
-                    combiner *= challenges.epsilon;
+                    combiner *= epsilon;
                     acc + *eval * combiner
                 });
 
-            combiner *= challenges.epsilon;
+            combiner *= epsilon;
             combiner /= challenges.beta;
             let beta_alpha = challenges.beta * challenges.alpha;
             perm_eval
                 + combiner
                     * ((beta_alpha - gkr_evals[6])
-                        + challenges.epsilon * (beta_alpha - gkr_evals[7])
-                        + challenges.epsilon * challenges.epsilon * gkr_evals[5])
+                        + epsilon * (beta_alpha - gkr_evals[7])
+                        + epsilon * epsilon * gkr_evals[5])
         } else if gkr_evals.len() == 4 {
             let mut combiner = P::ScalarField::one();
             gkr_evals[..4]
                 .iter()
                 .fold(P::ScalarField::zero(), |acc, eval| {
-                    combiner *= challenges.epsilon;
+                    combiner *= epsilon;
                     acc + *eval * combiner
                 })
         } else {
@@ -1158,6 +1173,10 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
                     "Could not evaluate pi poly".to_string(),
                 ))?;
 
+        let delta = transcript.squeeze_scalar_challenge::<P>(b"delta")?;
+
+        let full_challenges = FullMLEChallenges::from_parts(challenges, delta, epsilon);
+
         let zero_check_calc_eval = build_zerocheck_eval(
             &proof.evals,
             proof
@@ -1165,7 +1184,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
                 .as_ref()
                 .map(|lookup_proof| &lookup_proof.lookup_evals),
             &vk.gate_info,
-            &challenges,
+            &full_challenges,
             pi_poly_eval,
             zc_eq_eval,
         );
@@ -1239,7 +1258,7 @@ impl<PCS: PolynomialCommitmentScheme> MLEPlonk<PCS> {
         }
 
         let delta_powers = (0..comms.len() as u64)
-            .map(|i| challenges.delta.pow([i]))
+            .map(|i| delta.pow([i]))
             .collect::<Vec<P::ScalarField>>();
 
         let eval = evals

--- a/plonk/src/nightfall/mle/subroutines/sumcheck.rs
+++ b/plonk/src/nightfall/mle/subroutines/sumcheck.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use ark_ff::{Field, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::vec::Vec;
 use jf_relation::gadgets::{ecc::HasTEForm, EmulationConfig};
 
 /// A trait that defines what it means to be an oracle to a polynomial.
@@ -55,4 +56,10 @@ where
         proof: &Self::Proof,
         transcript: &mut T,
     ) -> Result<Self::DeferredCheck, PlonkError>;
+
+    /// Recovers the sumcheck challenges from the proof and transcript.
+    fn recover_sumcheck_challenges<T: Transcript>(
+        proof: &Self::Proof,
+        transcript: &mut T,
+    ) -> Result<Vec<P::ScalarField>, PlonkError>;
 }


### PR DESCRIPTION
Fixes #55. The challenges for MLE Plonk were not being squeezed at the correct time in the protocol. (See the issue for more details.) As there is now a GKR protocol in between the squeezing of these challenges, the protocol is significantly more complicated now. In particular, what was `MLEChallenges` is now called `FullMLEChallenges`, while `MLEChallenges` represents the four challenges squeezed before this GKR protocol.

This PR passes the recursive prover unit test.