### PR TITLE
add evals and lookup poly_evals to transcript

### DIFF
--- a/plonk/src/recursion/circuits/challenges.rs
+++ b/plonk/src/recursion/circuits/challenges.rs
@@ -199,6 +199,32 @@ where
     let final_sumcheck_challenges =
         circuit.recover_sumcheck_challenges::<P, C>(&proof_var.sumcheck_proof, &mut transcript)?;
 
+    // Append evals and lookup_proof.poly_evals to the transcript.
+    for eval in proof_var
+        .poly_evals_var
+        .wire_evals
+        .iter()
+        .chain(&proof_var.poly_evals_var.selector_evals)
+        .chain(&proof_var.poly_evals_var.permutation_evals)
+    {
+        transcript.push_emulated_variable(eval, circuit)?;
+    }
+
+    if let Some(lookup_proof) = &proof_var.lookup_proof_var {
+        for eval in [
+            &lookup_proof.poly_evals_var.m_poly_eval,
+            &lookup_proof.poly_evals_var.range_table_eval,
+            &lookup_proof.poly_evals_var.key_table_eval,
+            &lookup_proof.poly_evals_var.table_dom_sep_eval,
+            &lookup_proof.poly_evals_var.q_dom_sep_eval,
+            &lookup_proof.poly_evals_var.q_lookup_eval,
+        ]
+        .iter()
+        {
+            transcript.push_emulated_variable(eval, circuit)?;
+        }
+    }
+
     let delta = transcript.squeeze_scalar_challenge::<P>(circuit)?;
     let delta_var = circuit.to_emulated_variable(delta)?;
 

--- a/plonk/src/recursion/circuits/emulated_mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/emulated_mle_arithmetic.rs
@@ -332,6 +332,32 @@ pub(crate) fn verify_mleplonk_emulated_scalar_arithmetic(
     let zerocheck_eval =
         circuit.verify_emulated_proof::<SWGrumpkin>(&proof.sumcheck_proof, transcript)?;
 
+    // Append evals and lookup_proof.poly_evals to the transcript.
+    for eval in proof
+        .poly_evals_var
+        .wire_evals
+        .iter()
+        .chain(&proof.poly_evals_var.selector_evals)
+        .chain(&proof.poly_evals_var.permutation_evals)
+    {
+        transcript.push_emulated_variable(eval, circuit)?;
+    }
+
+    if let Some(lookup_proof) = &proof.lookup_proof_var {
+        for eval in [
+            &lookup_proof.poly_evals_var.m_poly_eval,
+            &lookup_proof.poly_evals_var.range_table_eval,
+            &lookup_proof.poly_evals_var.key_table_eval,
+            &lookup_proof.poly_evals_var.table_dom_sep_eval,
+            &lookup_proof.poly_evals_var.q_dom_sep_eval,
+            &lookup_proof.poly_evals_var.q_lookup_eval,
+        ]
+        .iter()
+        {
+            transcript.push_emulated_variable(eval, circuit)?;
+        }
+    }
+
     let delta = transcript.squeeze_scalar_challenge::<SWGrumpkin>(circuit)?;
     let delta_var = circuit.to_emulated_variable(delta)?;
 

--- a/plonk/src/recursion/circuits/mle_arithmetic.rs
+++ b/plonk/src/recursion/circuits/mle_arithmetic.rs
@@ -770,6 +770,30 @@ mod tests {
                 &mut transcript,
             )
             .unwrap();
+            // Append evals and lookup_proof.poly_evals to the transcript.
+            for eval in inner_proof
+                .evals
+                .wire_evals
+                .iter()
+                .chain(&inner_proof.evals.selector_evals)
+                .chain(&inner_proof.evals.permutation_evals)
+            {
+                transcript.push_message(b"eval", eval)?;
+            }
+            if let Some(lookup_proof) = inner_proof.lookup_proof.clone() {
+                for eval in [
+                    lookup_proof.lookup_evals.m_poly_eval,
+                    lookup_proof.lookup_evals.range_table_eval,
+                    lookup_proof.lookup_evals.key_table_eval,
+                    lookup_proof.lookup_evals.table_dom_sep_eval,
+                    lookup_proof.lookup_evals.q_dom_sep_eval,
+                    lookup_proof.lookup_evals.q_lookup_eval,
+                ]
+                .iter()
+                {
+                    transcript.push_message(b"lookup eval", eval)?;
+                }
+            }
             let delta = transcript.squeeze_scalar_challenge::<P>(b"delta").unwrap();
 
             let (opening_proof, _eval) = PCS::open(


### PR DESCRIPTION
Fixes the second half of Issue L [PS]. See https://teams.microsoft.com/l/message/19:RAT1CPL24X-Ic_3YWhmcGtJoBWLbPLMsZm1FBmVUgn41@thread.tacv2/1762867837456?tenantId=5b973f99-77df-4beb-b27d-aa0c70b8482c&groupId=d7f2ee4c-1ef4-4f2a-a04b-4c3f3d4b4c79&parentMessageId=1762867837456&teamName=Nightfall%20Security%20Audit&channelName=discussion&createdTime=1762867837456

Passes the recursive prover unit test