### PR TITLE
remove vk from PlonkKzgSnark transcript

### DIFF
--- a/plonk/src/proof_system/snark.rs
+++ b/plonk/src/proof_system/snark.rs
@@ -248,8 +248,7 @@ where
         } else {
             T::new_transcript(b"PlonkProof")
         };
-        for (pk, circuit) in prove_keys.iter().zip(circuits.iter()) {
-            transcript.append_visitor(&pk.vk)?;
+        for circuit in circuits {
             for pub_input in circuit.public_input()? {
                 transcript.push_message(b"public_input", &pub_input)?;
             }

--- a/plonk/src/proof_system/verifier.rs
+++ b/plonk/src/proof_system/verifier.rs
@@ -313,8 +313,7 @@ where
         } else {
             T::new_transcript(b"PlonkProof")
         };
-        for (&vk, &pi) in verify_keys.iter().zip(public_inputs.iter()) {
-            transcript.append_visitor(vk)?;
+        for pi in public_inputs {
             for pub_input in pi.iter() {
                 transcript.push_message(b"public_input", pub_input)?;
             }


### PR DESCRIPTION
Removes the `vk_hash` from the transcript for `PlonkKzgSanrk`. It is now added during the initialisation of the transcript, so this is now unnecessary. Currently testing the recursive unit test. I will not merge before it passes.